### PR TITLE
fix envfiles, docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/db/*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -614,7 +616,7 @@ pip-selfcheck.json
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
 
 # Thumbnails
 ._*
@@ -785,7 +787,7 @@ fabric.properties
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]
-!*.svg  # comment out if you don't need vector files
+!*.svg # comment out if you don't need vector files
 [._]*.sw[a-p]
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,6 +4,7 @@ volumes:
   pgdata:
   static:
 
+
 services:
   web:
     container_name: ${PROJECT_NAME}-web

--- a/envfiles/env.sample
+++ b/envfiles/env.sample
@@ -1,5 +1,5 @@
 DEBUG=True
-SECRET_KEY=django-insecure--9y3n9l!#_)-eubj@8-3&vie@p-#(c-hesl2vjwf3=(yuxl9#6
+SECRET_KEY="django-insecure--9y3n9l!#_)-eubj@8-3&vie@p-#(c-hesl2vjwf3=(yuxl9#6"
 DJANGO_ALLOWED_HOSTS=*
 POSTGRES_USER=
 POSTGRES_PASSWORD=

--- a/envfiles/env_dev
+++ b/envfiles/env_dev
@@ -1,6 +1,6 @@
 BUILD=dev
 DEBUG=True
-SECRET_KEY=django-insecure--9y3n9l!#_)-eubj@8-3&vie@p-#(c-hesl2vjwf3=(yuxl9#6
+SECRET_KEY="django-insecure--9y3n9l!#_)-eubj@8-3&vie@p-#(c-hesl2vjwf3=(yuxl9#6"
 DJANGO_ALLOWED_HOSTS=*
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=passw0rd


### PR DESCRIPTION
1. envfiles — fix parse exception
```
dotenv: found '.env' file. Source it? ([Y]es/[n]o/[a]lways/n[e]ver) Y
.env:2: parse error near `)'
dotenv: error when sourcing '.env' file
```

2. docker-compose — отсутствуют локальная директория на mac: `/srv/...`, вероятно лучше будет хранить БД рядом с реализацией проекта